### PR TITLE
Init.pp doesn't meet puppet style guidelines

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,11 +13,11 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class motd {
-  if $kernel == "Linux" {
+  if $::kernel == 'Linux' {
     file { '/etc/motd':
       ensure  => file,
       backup  => false,
-      content => template("motd/motd.erb"),
+      content => template('motd/motd.erb'),
     }
   }
 }


### PR DESCRIPTION
Puppet-lint shows a few spots where this module doesn't quite meet the style guidelines

```
WARNING: top-scope variable being used without an explicit namespace on line 16
WARNING: double quoted string containing no variables on line 16
WARNING: double quoted string containing no variables on line 20
```
