### PR TITLE
Generalize the MOTD module so that it can be used by multiple applications

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,23 +1,34 @@
 # Class: motd
 #
-# This module manages the /etc/motd file using a template
+# This module manages the /etc/motd file using a template. Using the input parameter appgroup, the same module can be
+# used for N number of different applications in your environment.
 #
-# Parameters:
+# Parameters: $appgroup
 #
 # Actions:
 #
 # Requires:
 #
 # Sample Usage:
-#  include motd
+#  class { 'motd': appgroup => 'app1' }
 #
 # [Remember: No empty lines between comments and class definition]
-class motd {
-  if $::kernel == 'Linux' {
+class motd ($appgroup=undef) {
+
+$templatefile = $appgroup ? {
+    'app1' => 'app1.erb',
+    'app2' => 'app2.erb',
+		'app3' => 'app3.erb'
+    }
+
+if $::kernel == 'Linux' {
     file { '/etc/motd':
       ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
       backup  => false,
-      content => template('motd/motd.erb'),
+      content => template("motd/${templatefile}")
     }
   }
 }


### PR DESCRIPTION
The changes I have mentioned generalizes the module and extend the 
usage to N number of applications in the environment. For instance, 
there are 10 different applications running on around 50 servers, the
same module can be used. There would be one template each for a
unique application.
