### PR TITLE
Updates MOTD content to use puppetversion

### DIFF
--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,3 +1,4 @@
 The operating system is <%= operatingsystem %>
-The free memory is <%= memoryfree %>
 The domain is <%= domain %>
+
+This system is being managed by Puppet Version: <%= puppetversion %>


### PR DESCRIPTION
instead of free memory

prevents puppet from updating the MOTD every puppet run due to using a constantly changing fact.
