### PR TITLE
fix a deprecation warning introduced by puppet issue 19058

### DIFF
--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,3 +1,3 @@
-The operating system is <%= operatingsystem %>
-The free memory is <%= memoryfree %>
-The domain is <%= domain %>
+The operating system is <%= @operatingsystem %>
+The free memory is <%= @memoryfree %>
+The domain is <%= @domain %>


### PR DESCRIPTION
Feature#19058 deprecates the var/method call syntax
