### PR TITLE
fixed static string example that would not display MOTD on CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you would like to change the location of the template:
 If you would like to provide a static string as the MOTD content you can use the content parameter:
 
     class { 'motd':
-      content => 'Hello!',
+      content => "Hello!\n",
     }
 
 Limitations


### PR DESCRIPTION
Hi,

The example given in the README for providing a static string as the MOTD did not work without adding a newline character (`\n`) at the end .

Perhaps you could do something within the `init.pp` to ensure a newline is inserted at the end (HTH) but at least the README example will now work.

This was tested on CentOS `6.5` using Puppet `3.6.2`.
