### PR TITLE
Added option to disable dynamic motd on Debian based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Motd utilizes the contents of `motd/motd.erb` to populate `etc/motd`. You must d
 
 Motd utilizes the content of `motd/motd.erb` to populate the legalnoticetext registry key, which is shown before login on a Windows System
 
+* dynamic motd on Debian based systems 
+
+Motd has the option to disable the dynamic motd messages on Debian based systems, by default no changes will be made
+
 Usage
 ------
 
@@ -40,6 +44,12 @@ If you would like to provide a static string as the MOTD content you can use the
     class { 'motd':
       content => "Hello!\n",
     }
+
+If you would like to disable the dynamic motd on Debian based systems: 
+    
+    class { 'motd': 
+      dynamic_motd => false,
+    } 
 
 Limitations
 ------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class motd (
+  $dynamic_motd = true, 
   $template = undef,
   $content = undef,
 ) {
@@ -35,6 +36,13 @@ class motd (
       ensure  => file,
       backup  => false,
       content => $motd_content,
+    }
+    if ($::osfamily == 'Debian') and ($dynamic_motd == false) {
+      file_line { 'dynamic_motd': 
+        ensure => absent, 
+        path   => '/etc/pam.d/sshd', 
+        line   => 'session    optional     pam_motd.so  motd=/run/motd.dynamic noupdate', 
+      }
     }
   } elsif $::kernel == 'windows' {
     registry_value { 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticecaption':

--- a/metadata.json
+++ b/metadata.json
@@ -27,5 +27,6 @@
   ],
   "dependencies": [
      {"name":"puppetlabs/registry","version_requirement":"1.x"}, 
+     {"name":"puppetlabs/stdlib","version_requirement":">=2.1.0"}, 
   ]
 }

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -78,6 +78,24 @@ describe 'motd', :type => :class do
       }
     end
   end
+
+  describe "On Debian based Operating Systems" do 
+    let(:facts) {{
+      :kernel    => 'Linux',
+      :osfamily  => 'Debian',
+    }}
+   
+    context "When dynamic motd is false" do 
+      let(:params) { { :dynamic_motd => false } }
+      it { should contain_file_line('dynamic_motd').with_line('session    optional     pam_motd.so  motd=/run/motd.dynamic noupdate') }
+    end
+
+    context "When dynamic motd is true" do 
+      let(:params) { { :dynamic_motd => true } }
+      it { should_not contain_file_line('dynamic_motd') }
+    end
+  end 
+      
   describe "On Windows" do
     let(:facts) {{
       :kernel          => 'windows',


### PR DESCRIPTION
Added option to disable the dynamic motd on Debian based systems, added rspec-puppet tests. Updated readme and added dependancy on stdlib in metadata.json file. 