### PR TITLE
Add missing stdlib fixture

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     registry:
       repo: 'git://github.com/puppetlabs/puppetlabs-registry.git'
       ref: '1.1.0'


### PR DESCRIPTION
This PR fixes:

```
.......F..

Failures:

  1) motd On Debian based    Operating Systems When dynamic motd is false should contain File_line[dynamic_motd] with line => "session    optional     pam_motd.so  motd=/run/motd.dynamic noupdate"
     Failure/ Error: it { should contain_file_line('dynamic_motd').with_line('session    optional     pam_motd.so  motd=/run/motd.dynamic noupdate') }
     Puppet::Error:
       Puppet::Parser::A    ST::Resource failed with error ArgumentError: Invalid resource type file_line at motd/spec/fixtures/modules/motd/manifests/init.pp:45 on node buildserver
     # ./spec/classes /motd_spec.rb:90:in `block (4 levels) in <top (required)>'

Finished in 0.62725 seconds
  110 examples, 1 failure
```