### PR TITLE
Cut 1.3.0 release - MODULES-2845

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Release 1.3.0
+### Summary
+This release adds documentation updates, test improvements, and os support.
+
+#### Features:
+- Acceptance testing on Linux platforms
+- Rewritten documentation, inclusion of strings for automated documentation.
+- Linting of manifest to conform to style guidelines.
+- Adds support for several operating systems:
+  - Debian 6, 7
+  - CentOS 5, 6, 7
+  - Oracle Linux 6, 7
+  - Scientific Linux 5, 6, 7
+
 ### 2014-10-31 Release 1.2.0
 ### Summary
 - Add content parameter to allow setting static motd content
@@ -18,10 +32,10 @@ It also includes documentation and testing improvements.
 
 - Added class parameter to support external templates
 - Updated README documentation
-- Improved Testing 
+- Improved Testing
 
 ####Fixes
 
-- Add LICENSE file 
+- Add LICENSE file
 
 ####Known Bugs

--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,8 @@ else
   gem 'puppet', :require => false
 end
 
+if RUBY_VERSION < '2.0'
+  gem 'mime-types', '<3.0', :require => false
+end
+
 # vim:ft=ruby

--- a/metadata.json
+++ b/metadata.json
@@ -1,29 +1,83 @@
 {
   "name": "puppetlabs-motd",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "puppetlabs",
   "summary": "A simple module to demonstrate managing /etc/motd or Windows Logon Message as a template",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-motd",
   "project_page": "https://github.com/puppetlabs/puppetlabs-motd",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "data_provider": null,
   "description": "This module simply manages /etc/motd or the Windows Logon Message as a template, showing interpolation of system attributes",
   "operatingsystem_support": [
-     {
-        "operatingsystem":"RedHat",
-        "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
-     },
-     {
-        "operatingsystem": "Ubuntu",
-        "operatingsystemrelease": [ "12.04", "12.10", "14.04" ]
-      },
-      {
-        "operatingsystem": "Windows",
-        "operatingsystemrelease": [ "2008", "2008 R2", "2012", "2012 R2" ]
-      }
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "2008",
+        "2008 R2",
+        "2012",
+        "2012 R2"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.0.0 < 2015.3.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.0.0 < 5.0.0"
+    }
   ],
   "dependencies": [
-     {"name":"puppetlabs/registry","version_requirement":"1.x"}, 
-     {"name":"puppetlabs/stdlib","version_requirement":">=2.1.0"}
+    {"name":"puppetlabs/registry","version_requirement":">= 1.0.0 < 2.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 2.1.0 < 5.0.0"}
   ]
 }


### PR DESCRIPTION
[MODULES-2845](https://tickets.puppetlabs.com/browse/MODULES-2845)

From `CHANGELOG.md`:
## 2015-11-18 Release 1.3.0
### Summary
This release adds documentation updates, test improvements, and os support.

#### Features:
- Acceptance testing on Linux platforms
- Rewritten documentation, inclusion of strings for automated documentation.
- Linting of manifest to conform to style guidelines.
- Adds support for several Operating Systems:
  - Debian 6, 7
  - CentOS 5, 6, 7
  - Oracle Linux 6, 7
  - Scientific Linux 5, 6, 7