### PR TITLE
(maint) Removes unnecessary test

### DIFF
--- a/spec/acceptance/motd_spec.rb
+++ b/spec/acceptance/motd_spec.rb
@@ -19,22 +19,6 @@ describe 'static message from content' do
       it { should contain "Hello world!\n" }
     end
   end
-
-  # Check that dynamic motd settings are unchanged on Debian.
-  if fact('osfamily') == 'Debian'
-    describe file('/etc/pam.d/sshd') do
-      if (fact('operatingsystem') == 'Ubuntu' and fact('operatingsystemmajrelease').to_f > 12.10)
-        its(:content) { should match /session    optional     pam_motd.so  motd=\/run\/motd.dynamic noupdate/ }
-        its(:content) { should match /session    optional     pam_motd.so # \[1\]/ }
-      elsif (fact('operatingsystem') == 'Debian' and fact('operatingsystemmajrelease').to_f > 7)
-        its(:content) { should match /session    optional     pam_motd.so  motd=\/run\/motd.dynamic/ }
-        its(:content) { should match /session    optional     pam_motd.so noupdate/ }
-      elsif (fact('operatingsystem') == 'Debian' and fact('operatingsystemmajrelease').to_f > 6)
-        its(:content) { should match /session    optional     pam_motd.so  motd=\/run\/motd.dynamic noupdate/ }
-        its(:content) { should match /session    optional     pam_motd.so # \[1\]/ }
-      end
-    end
-  end
 end
 
 describe 'static message from template' do


### PR DESCRIPTION
The test to validate dynamic_motd on Debian platforms is unnecessary
because the default for dynamic_motd is true, and the block of code that
modifies the config file is never touched by the module in this usecase.