### PR TITLE
(#5955) Support for /etc/issue and /etc/issue.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ Specifies a static string as the motd content. Valid options: A string, such as 
 
 Enables or disables dynamic motd on Debian systems. Valid options:  true or false. Default: true.
 
+##### `issue_template`
+
+Specifies a custom template to process and save to `/etc/issue`. A template take precedence over `issue_content`. Valid options:  '/mymodule/mytemplate.erb'. Default: 'undef'.
+
+##### `issue_content`
+
+Specifies a static string as the `/etc/issue` content. Valid options: A string, such as "Hello!\n", or "Please lock workstations when not in use\n". Default: 'undef'.
+
+##### `issue_net_template`
+
+Specifies a custom template to process and save to `/etc/issue.net`. A template take precedence over `issue_net_content`. Valid options:  '/mymodule/mytemplate.erb'. Default: 'undef'.
+
+##### `issue__net_content`
+
+Specifies a static string as the `/etc/issue.net` content. Valid options: A string, such as "Hello!\n", or "Please lock workstations when not in use\n". Default: 'undef'.
+
 ## Limitations
 
 This module has been tested on the following platforms:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To configure motd on your system, include the `motd` class: `include motd`.
 
 ## Usage
 
-The motd module configures the message of the day on a wide variety of systems. The module populates either `/etc/motd` (on POSIX systems) or a registry key (on Windows systems) with the contents of a basic template file.
+The motd module configures the message of the day on a wide variety of systems. The module populates either `/etc/motd`, `/etc/issue` and `/etc/issue.net` (on POSIX systems) or a registry key (on Windows systems) with the contents of a basic template file.
 
 By default, the module populates motd using the included template. Alternatively, you can specify a different template or a static string. For example, to use a custom template you would set the template parameter:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,10 @@
 # @param dynamic_motd [Bool] Enable or disable dynamic motd on Debian systems
 # @param template [String] Allows for custom template location
 # @param content [String] String to be used for motd, priority given to template
+# @param issue_template [String] Allows for custom template location for /etc/issue
+# @param issue_content [String] String to be used for /etc/issue, priority given to template
+# @param issue_net_template [String] Allows for custom template location for /etc/issue.net
+# @param issue_net_content [String] String to be used for /etc/issue.net, priority given to template
 #
 # @example
 #  include motd
@@ -13,6 +17,10 @@ class motd (
   $dynamic_motd = true,
   $template = undef,
   $content = undef,
+  $issue_template = undef,
+  $issue_content = undef,
+  $issue_net_template = undef,
+  $issue_net_content = undef,
 ) {
 
   if $template {
@@ -26,12 +34,51 @@ class motd (
     $motd_content = template('motd/motd.erb')
   }
 
+  if $issue_template {
+    if $issue_content {
+        warning('Both $issue_template and $issue_content parameters passed to motd, ignoring issue_content')
+    }
+    $_issue_content = template($issue_template)
+  } elsif $issue_content {
+    $_issue_content = $issue_content
+  } else {
+    $_issue_content = false
+  }
+
+  if $issue_net_template {
+    if $issue_net_content {
+        warning('Both $issue_net_template and $issue_net_content parameters passed to motd, ignoring issue_net_content')
+    }
+    $_issue_net_content = template($issue_net_template)
+  } elsif $issue_net_content {
+    $_issue_net_content = $issue_net_content
+  } else {
+    $_issue_net_content = false
+  }
+
   if $::kernel == 'Linux' {
     file { '/etc/motd':
       ensure  => file,
       backup  => false,
       content => $motd_content,
     }
+
+    if $_issue_content {
+      file { '/etc/issue':
+        ensure  => file,
+        backup  => false,
+        content => $_issue_content,
+      }
+    }
+
+    if $_issue_net_content {
+      file { '/etc/issue.net':
+        ensure  => file,
+        backup  => false,
+        content => $_issue_net_content,
+      }
+    }
+
     if ($::osfamily == 'Debian') and ($dynamic_motd == false) {
       if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '7') > 0 {
         $_line_to_remove = 'session    optional     pam_motd.so  motd=/run/motd.dynamic'

--- a/spec/acceptance/motd_spec.rb
+++ b/spec/acceptance/motd_spec.rb
@@ -42,6 +42,96 @@ describe 'static message from template' do
   end
 end
 
+describe 'static message from content in /etc/issue' do
+  it do
+    pp = <<-EOS
+      class { motd:
+        issue_content => "Hello world!\n",
+        content       => "Hello world!\n",
+      }
+    EOS
+    # Run it twice and test for idempotency
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+
+  if fact('osfamily') != 'windows'
+    describe file('/etc/issue') do
+      it { is_expected.to be_file }
+      it { should contain "Hello world!\n" }
+    end
+  end
+end
+
+
+describe 'static message from template in /etc/issue' do
+  it do
+    pp = <<-EOS
+      class { motd:
+        issue_template => "motd/spec.erb",
+        content        => "Hello world!\n",
+      }
+    EOS
+    # Run it twice and test for idempotency
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+
+  if fact('osfamily') != 'windows'
+    describe file('/etc/issue') do
+      it { is_expected.to be_file }
+      it { should contain "Test Template for Rspec" }
+    end
+  end
+end
+
+describe 'static message from content in /etc/issue.net' do
+  it do
+    pp = <<-EOS
+      class { motd:
+        issue_net_content => "Hello world!\n",
+        content           => "Hello world!\n",
+      }
+    EOS
+    # Run it twice and test for idempotency
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+
+  if fact('osfamily') != 'windows'
+    describe file('/etc/issue.net') do
+      it { is_expected.to be_file }
+      it { should contain "Hello world!\n" }
+    end
+  end
+end
+
+
+describe 'static message from template in /etc/issue.net' do
+  it do
+    pp = <<-EOS
+      class { motd:
+        issue_net_template => "motd/spec.erb",
+        content            => "Hello world!\n",
+      }
+    EOS
+    # Run it twice and test for idempotency
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+
+  if fact('osfamily') != 'windows'
+    describe file('/etc/issue.net') do
+      it { is_expected.to be_file }
+      it { should contain "Test Template for Rspec" }
+    end
+  end
+end
+
 describe 'disable dynamic motd settings on Debian', :if => fact('osfamily') == 'Debian' do
   it do
     pp = <<-EOS

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -9,6 +9,8 @@ describe 'motd', type: :class do
       end.not_to raise_error
     end
     it { should_not contain_file('/etc/motd') }
+    it { should_not contain_file('/etc/issue') }
+    it { should_not contain_file('/etc/issue.net') }
   end
 
   describe 'On Linux - no ::domain' do
@@ -83,6 +85,84 @@ describe 'motd', type: :class do
       let(:params) { { template: 'motd/spec.erb' } }
       it do
         should contain_File('/etc/motd').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "Test Template for Rspec\n"
+        )
+      end
+    end
+
+    context 'When a template is specified for /etc/issue' do
+      let(:params) { { issue_template: 'motd/spec.erb' } }
+      it do
+        should contain_File('/etc/issue').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "Test Template for Rspec\n"
+        )
+      end
+    end
+
+    context 'When content is specified for /etc/issue' do
+      let(:params) { { issue_content: 'Hello!' } }
+      it do
+        should contain_File('/etc/issue').with(
+          ensure: 'file',
+          backup: 'false',
+          content: 'Hello!'
+        )
+      end
+    end
+
+    context 'When both content and template is specified for /etc/issue' do
+      # FIXME duplicate behaviour described in FM-5956 until I'm allowed to fix it
+      let(:params) do
+        {
+          issue_content: 'Hello!',
+          issue_template: 'motd/spec.erb'
+        }
+      end
+      it do
+        should contain_File('/etc/issue').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "Test Template for Rspec\n"
+        )
+      end
+    end
+
+    context 'When a template is specified for /etc/issue.net' do
+      let(:params) { { issue_net_template: 'motd/spec.erb' } }
+      it do
+        should contain_File('/etc/issue.net').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "Test Template for Rspec\n"
+        )
+      end
+    end
+
+    context 'When content is specified for /etc/issue.net' do
+      let(:params) { { issue_net_content: 'Hello!' } }
+      it do
+        should contain_File('/etc/issue.net').with(
+          ensure: 'file',
+          backup: 'false',
+          content: 'Hello!'
+        )
+      end
+    end
+
+    context 'When both content and template is specified for /etc/issue.net' do
+      # FIXME duplicate behaviour described in FM-5956 until I'm allowed to fix it
+      let(:params) do
+        {
+          issue_net_content: 'Hello!',
+          issue_net_template: 'motd/spec.erb'
+        }
+      end
+      it do
+        should contain_File('/etc/issue.net').with(
           ensure: 'file',
           backup: 'false',
           content: "Test Template for Rspec\n"


### PR DESCRIPTION
Introduces new parameters: issue_template, issue_content, issue_net_template, issue_net_content - to control what if anything is written to /etc/issue and /etc/issue.net respectively.  Includes tests and documentation.