### PR TITLE
(MODULES-3593) Changes default MOTD to something more useful

### DIFF
--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -174,15 +174,28 @@ describe 'motd', type: :class do
       it { should_not contain_file_line('dynamic_motd') }
     end
   end
-
   describe 'On Windows' do
     let(:facts) do
       {
         kernel: 'windows',
         operatingsystem: 'TestOS',
-        memoryfree: '1 KB',
-        domain: 'testdomain'
+        operatingsystemrelease: 5,
+        osfamily: 'windows',
+        architecture: 'x86_64',
+        processor1: 'intel awesome',
+        fqdn: 'test.example.com',
+        ipaddress: '123.23.243.1',
+        memoryfree: '1 KB'
       }
+    end
+    context 'When neither template or source are specified' do
+      it do
+        should contain_Registry_value('HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticetext').with(
+          ensure: 'present',
+          type: 'string',
+          data: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       windows\nMemory Free:  1 KB\n"
+        )
+      end
     end
     context 'When content is specified' do
       let(:params) do

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -13,35 +13,18 @@ describe 'motd', type: :class do
     it { should_not contain_file('/etc/issue.net') }
   end
 
-  describe 'On Linux - no ::domain' do
-    let(:facts) do
-      {
-        kernel: 'Linux',
-        operatingsystem: 'TestOS',
-        osfamily: 'Debian',
-        memoryfree: '1 KB',
-        domain: nil
-      }
-    end
-    context 'When ::domain is not present and a template has not been specified' do
-      it do
-        should contain_File('/etc/motd').with(
-          ensure: 'file',
-          backup: 'false',
-          content: "The operating system is TestOS\nThe free memory is 1 KB\n"
-        )
-      end
-    end
-  end
-
   describe 'On Linux' do
     let(:facts) do
       {
         kernel: 'Linux',
         operatingsystem: 'TestOS',
+        operatingsystemrelease: 5,
         osfamily: 'Debian',
-        memoryfree: '1 KB',
-        domain: 'testdomain'
+        architecture: 'x86_64',
+        processor1: 'intel awesome',
+        fqdn: 'test.example.com',
+        ipaddress: '123.23.243.1',
+        memoryfree: '1 KB'
       }
     end
     context 'When neither template or source are specified' do
@@ -49,7 +32,7 @@ describe 'motd', type: :class do
         should contain_File('/etc/motd').with(
           ensure: 'file',
           backup: 'false',
-          content: "The operating system is TestOS\nThe free memory is 1 KB\nThe domain is testdomain\n"
+          content: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       Linux\nMemory Free:  1 KB\n"
         )
       end
     end

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -21,7 +21,7 @@ describe 'motd', type: :class do
         operatingsystemrelease: 5,
         osfamily: 'Debian',
         architecture: 'x86_64',
-        processor1: 'intel awesome',
+        processor0: 'intel awesome',
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
         memoryfree: '1 KB'
@@ -182,7 +182,7 @@ describe 'motd', type: :class do
         operatingsystemrelease: 5,
         osfamily: 'windows',
         architecture: 'x86_64',
-        processor1: 'intel awesome',
+        processor0: 'intel awesome',
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
         memoryfree: '1 KB'

--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,6 +1,6 @@
 <%= @operatingsystem %> <%= @operatingsystemrelease %> <%= @architecture %>
 
 FQDN:         <%= @fqdn %> (<%= @ipaddress %>)
-Processor:    <%= @processor1 %>
+Processor:    <%= @processor0 %>
 Kernel:       <%= @kernel %>
 Memory Free:  <%= @memoryfree %>

--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,5 +1,6 @@
-The operating system is <%= @operatingsystem %>
-The free memory is <%= @memoryfree %>
-<%- if @domain -%>
-The domain is <%= @domain %>
-<%- end -%>
+<%= @operatingsystem %> <%= @operatingsystemrelease %> <%= @architecture %>
+
+FQDN:         <%= @fqdn %> (<%= @ipaddress %>)
+Processor:    <%= @processor1 %>
+Kernel:       <%= @kernel %>
+Memory Free:  <%= @memoryfree %>


### PR DESCRIPTION
Improves out-of-the-box useability. Changes default message to include FQDN, Processor, and Kernel in addition to the old messages Operating system and free memory. Removes domain as this is included in FQDN. Removes test to test when domain fact is nil.