### PR TITLE
(MODULES-6650) - PDK update 1.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,10 @@
 /Gemfile.lock
 /junit/
 /log/
-/log/
 /pkg/
 /spec/fixtures/manifests/
 /spec/fixtures/modules/
 /tmp/
 /vendor/
 /convert_report.txt
+.DS_Store

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,8 @@ Style/TrailingCommaInLiteral:
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets
+RSpec/MessageSpies:
+  EnforcedStyle: receive
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:

--- a/.sync.yml
+++ b/.sync.yml
@@ -23,8 +23,8 @@ appveyor.yml:
   branches:
     - release
   extras:
-    - rvm: 2.1.9
-      script: "\"bundle exec rake release_checks\""
+    - env: CHECK=release_checks
+      rvm: 2.1.9
 
 Gemfile:
   required:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - bundle -v
   - rm Gemfile.lock || true
   - gem update --system
+  - gem update bundler
   - gem --version
   - bundle -v
 script:
@@ -14,9 +15,7 @@ script:
 bundler_args: --without system_tests
 rvm:
   - 2.4.1
-  - 2.1.9
 env:
-  - PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
   - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
 matrix:
   fast_finish: true
@@ -44,8 +43,13 @@ matrix:
     -
       env: CHECK=metadata_lint
     -
+      env: CHECK=spec
+    -
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
       rvm: 2.1.9
-      script: "bundle exec rake release_checks"
+    -
+      env: CHECK=release_checks
+      rvm: 2.1.9
 branches:
   only:
     - master

--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,1 @@
 --markup markdown
---output-dir docs/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ init:
   - 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
   - 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
 environment:
-  PUPPET_GEM_VERSION: ~> 4.0
   matrix:
     -
       RUBY_VERSION: 24-x64
@@ -21,10 +20,16 @@ environment:
       RUBY_VERSION: 24-x64
       CHECK: rubocop
     -
-      RUBY_VERSION: 24-x64
+      PUPPET_GEM_VERSION: ~> 4.0
+      RUBY_VERSION: 21
       CHECK: spec
     -
+      PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21-x64
+      CHECK: spec
+    -
+      PUPPET_GEM_VERSION: ~> 5.0
+      RUBY_VERSION: 24
       CHECK: spec
     -
       PUPPET_GEM_VERSION: ~> 5.0
@@ -34,17 +39,6 @@ matrix:
   fast_finish: true
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-  # Due to a bug in the version of OpenSSL shipped with Ruby 2.4.1 on Windows
-  # (https://bugs.ruby-lang.org/issues/11033). Errors are ignored because the
-  # mingw gem calls out to pacman to install OpenSSL which is already
-  # installed, causing gem to raise a warning that powershell determines to be
-  # a fatal error.
-  - ps: |
-      $ErrorActionPreference = "SilentlyContinue"
-      if($env:RUBY_VERSION -eq "24-x64") {
-        gem install openssl "~> 2.0.4" --no-rdoc --no-ri -- --with-openssl-dir=C:\msys64\mingw64
-      }
-      $host.SetShouldExit(0)
   - bundle install --jobs 4 --retry 2 --without system_tests
   - type Gemfile.lock
 build: off

--- a/metadata.json
+++ b/metadata.json
@@ -82,5 +82,6 @@
   ],
   "description": "This module simply manages /etc/motd or the Windows Logon Message as a template, showing interpolation of system attributes",
   "template-url": "https://github.com/puppetlabs/pdk-templates",
-  "template-ref": "1.3.2-0-g07678c8"
+  "template-ref": "heads/master-0-gc0124ea",
+  "pdk-version": "1.4.1"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
+
+begin
+  require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
+rescue LoadError => loaderror
+  warn "Could not require spec_helper_local: #{loaderror.message}"
+end
+
 include RspecPuppetFacts
 
 default_facts = {


### PR DESCRIPTION
The main reason for running this `pdk update` is that the initial convert removed 32 bit testing on appveyor, this PR will enable this again.