### PR TITLE
(MODULES-7069) Add compatibility for AIX

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,7 +9,7 @@
   branches:
     - release
   extras:
-    - env: CHECK=release_checks
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=release_checks
       rvm: 2.1.9
 
 Gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
       rvm: 2.1.9
     -
-      env: CHECK=release_checks
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=release_checks
       rvm: 2.1.9
 branches:
   only:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,11 +56,28 @@ class motd (
     $_issue_net_content = false
   }
 
-  File {
-    mode => '0644',
+  $owner = $::kernel ? {
+    'AIX'   => 'bin',
+    default => undef,
   }
 
-  if ($::kernel == 'Linux') or ($::kernel == 'SunOS') or ($::kernel == 'FreeBSD') {
+  $group = $::kernel ? {
+    'AIX'   => 'bin',
+    default => undef,
+  }
+
+  $mode = $::kernel ? {
+    'AIX'   => '0444',
+    default => '0644',
+  }
+
+  File {
+    owner => $owner,
+    group => $group,
+    mode  => $mode,
+  }
+
+  if $::kernel in ['Linux', 'SunOS', 'FreeBSD', 'AIX']  {
     file { '/etc/motd':
       ensure  => file,
       backup  => false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,12 +58,12 @@ class motd (
 
   $owner = $::kernel ? {
     'AIX'   => 'bin',
-    default => undef,
+    default => 'root',
   }
 
   $group = $::kernel ? {
     'AIX'   => 'bin',
-    default => undef,
+    default => 'root',
   }
 
   $mode = $::kernel ? {

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -292,4 +292,60 @@ describe 'motd', type: :class do
       end
     end
   end
+  describe 'On AIX' do
+    let(:facts) do
+      {
+        kernel: 'AIX',
+        operatingsystem: 'AIX',
+        operatingsystemrelease: '7100-04-02-1614',
+        osfamily: 'AIX',
+        architecture: 'PowerPC_POWER8',
+        processor0: 'PowerPC_POWER8',
+        fqdn: 'test.example.com',
+        ipaddress: '123.23.243.1',
+        memoryfree: '1 KB',
+      }
+    end
+
+    context 'when neither template or source are specified' do
+      it do
+        is_expected.to contain_File('/etc/motd').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "AIX 7100-04-02-1614 PowerPC_POWER8\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    \PowerPC_POWER8\nKernel:       AIX\nMemory Free:  1 KB\n",
+          owner:  'bin',
+          group:  'bin',
+          mode:   '0444',
+        )
+      end
+    end
+    context 'when a template is specified for /etc/issue' do
+      let(:params) { { issue_template: 'motd/spec.erb' } }
+
+      it do
+        is_expected.to contain_File('/etc/issue').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "Test Template for Rspec\n",
+          owner:  'bin',
+          group:  'bin',
+          mode:   '0444',
+        )
+      end
+    end
+    context 'when a template is specified for /etc/issue.net' do
+      let(:params) { { issue_net_template: 'motd/spec.erb' } }
+
+      it do
+        is_expected.to contain_File('/etc/issue.net').with(
+          ensure: 'file',
+          backup: 'false',
+          content: "Test Template for Rspec\n",
+          owner:  'bin',
+          group:  'bin',
+          mode:   '0444',
+        )
+      end
+    end
+  end
 end

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -33,6 +33,9 @@ describe 'motd', type: :class do
           ensure: 'file',
           backup: 'false',
           content: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       Linux\nMemory Free:  1 KB\n",
+          owner:  'root',
+          group:  'root',
+          mode:   '0644',
         )
       end
     end
@@ -86,6 +89,9 @@ describe 'motd', type: :class do
           ensure: 'file',
           backup: 'false',
           content: "Test Template for Rspec\n",
+          owner:  'root',
+          group:  'root',
+          mode:   '0644',
         )
       end
     end
@@ -128,6 +134,9 @@ describe 'motd', type: :class do
           ensure: 'file',
           backup: 'false',
           content: "Test Template for Rspec\n",
+          owner:  'root',
+          group:  'root',
+          mode:   '0644',
         )
       end
     end


### PR DESCRIPTION
This PR adds support for AIX to specify a `/etc/motd`, `/etc/issue` and `/etc/issue.net`. 