### PR TITLE
(maint) removing registry pin, update stdlib bound

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,6 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    registry:
-      repo: 'git://github.com/puppetlabs/puppetlabs-registry.git'
-      ref: '1.1.0'
+    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    registry: 'git://github.com/puppetlabs/puppetlabs-registry.git'
   symlinks:
     "motd": "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.1.0 < 5.0.0"
+      "version_requirement": ">= 2.1.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -9,11 +9,4 @@ install_module_dependencies_on(hosts)
 
 RSpec.configure do |c|
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    hosts.select { |host| host['platform'] =~ %r{windows}i }.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-registry')
-    end
-  end
 end


### PR DESCRIPTION
Bumping puppetlabs-stdlib upper boundary as puppetlabs-stdlib 5.0.0 has been released. 
Removing the pin to registry as it is now on version 2.2.0 and the pinned version was very old. 
Finally removing the install code in `puppetlabs_spec_helper_acceptance.rb` as there is no need to install the registry modules again when it is listed in `.fixtures.yml` and `metadata.json`.