### PR TITLE
Fa 6043 file ownership

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,6 @@ class motd (
   }
 
   $mode = $facts['kernel'] ? {
-    'AIX'   => '0644',
     default => '0644',
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,7 @@ class motd (
   }
 
   $mode = $facts['kernel'] ? {
-    'AIX'   => '0444',
+    'AIX'   => '0644',
     default => '0644',
   }
 

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -330,7 +330,7 @@ describe 'motd', type: :class do
           content: "AIX 7100-04-02-1614 PowerPC_POWER8\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    \PowerPC_POWER8\nKernel:       AIX\nMemory Free:  1 KB\n",
           owner:  'bin',
           group:  'bin',
-          mode:   '0444',
+          mode:   '0644',
         )
       end
     end
@@ -344,7 +344,7 @@ describe 'motd', type: :class do
           content: "Test Template for Rspec\n",
           owner:  'bin',
           group:  'bin',
-          mode:   '0444',
+          mode:   '0644',
         )
       end
     end
@@ -358,7 +358,7 @@ describe 'motd', type: :class do
           content: "Test Template for Rspec\n",
           owner:  'bin',
           group:  'bin',
-          mode:   '0444',
+          mode:   '0644',
         )
       end
     end


### PR DESCRIPTION
Support for AIX was already added by PR (https://github.com/puppetlabs/puppetlabs-motd/commit/0c11429235fd73c30a1ee137fbbe299e9491bb63)
I updated mode for AIX to 0644 as required and spec accordingly 