### PR TITLE
Update documentation to match epp templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ By default, the module populates motd using the included template. Alternatively
 
 ```puppet
 class { 'motd':
-  template => 'mymodule/mytemplate.erb',
+  template => 'mymodule/mytemplate.epp',
 }
 ```
 


### PR DESCRIPTION
Following the documentation currently doesn't work as the `epp` function looks for and then adds the `epp` extension.