### PR TITLE
(FM-7522) - Updating metadata.json to contain Oracle 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,7 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
+        "5",
         "6",
         "7"
       ]


### PR DESCRIPTION
Currently our internal CI is testing and passing on Oracle5. As we support Oracle 6 and 7 I have also now added Oracle 5 to the OS list.