### PR TITLE
pdksync - (FM-7655) Fix rubygems-update for ruby < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system
+  - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
 script:
@@ -43,7 +43,7 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
     -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8
       rvm: 2.1.9
 branches:
   only:

--- a/metadata.json
+++ b/metadata.json
@@ -92,7 +92,7 @@
     }
   ],
   "description": "This module simply manages /etc/motd or the Windows Logon Message as a template, showing interpolation of system attributes",
-  "template-url": "https://github.com/puppetlabs/pdk-templates",
-  "template-ref": "heads/master-0-gbf720df",
+  "template-url": "https://github.com/puppetlabs/pdk-templates/",
+  "template-ref": "heads/master-0-g20af4c6",
   "pdk-version": "1.8.0"
 }


### PR DESCRIPTION
(FM-7655) Fix rubygems-update for ruby < 2.3
pdk version: `1.8.0` 
