### PR TITLE
(MODULES-8758) Change memoryfree to memorysize in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,45 +41,9 @@ class { 'motd':
 }
 ```
 
-
 ## Reference
+
 See [REFERENCE.md](https://github.com/puppetlabs/puppetlabs-motd/blob/master/REFERENCE.md)
-
-#### Public classes
-
-* `motd`: Configures the message of the day.
-
-#### Parameters
-
-The following parameters are available in `motd`. All parameters are optional.
-
-##### `template`
-
-Specifies a custom EPP template. A template take precedence over `content`. Valid options:  '/mymodule/mytemplate.epp'. Default: 'undef'.
-
-##### `content`
-
-Specifies a static string as the motd content. Valid options: A string, such as "Hello!\n", or "Please lock workstations when not in use\n". Default: 'undef'.
-
-##### `dynamic_motd`
-
-Enables or disables dynamic motd on Debian systems. Valid options:  true or false. Default: true.
-
-##### `issue_template`
-
-Specifies a custom EPP template to process and save to `/etc/issue`. A template take precedence over `issue_content`. Valid options:  '/mymodule/mytemplate.epp'. Default: 'undef'.
-
-##### `issue_content`
-
-Specifies a static string as the `/etc/issue` content. Valid options: A string, such as "Hello!\n", or "Please lock workstations when not in use\n". Default: 'undef'.
-
-##### `issue_net_template`
-
-Specifies a custom EPP template to process and save to `/etc/issue.net`. A template take precedence over `issue_net_content`. Valid options:  '/mymodule/mytemplate.epp'. Default: 'undef'.
-
-##### `issue_net_content`
-
-Specifies a static string as the `/etc/issue.net` content. Valid options: A string, such as "Hello!\n", or "Please lock workstations when not in use\n". Default: 'undef'.
 
 ## Limitations
 

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -23,7 +23,7 @@ describe 'motd', type: :class do
         processor0: 'intel awesome',
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
-        memoryfree: '1 KB',
+        memorysize: '16.00 GB',
       }
     end
 
@@ -32,7 +32,7 @@ describe 'motd', type: :class do
         is_expected.to contain_File('/etc/motd').with(
           ensure: 'file',
           backup: 'false',
-          content: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       Linux\nMemory Free:  1 KB\n",
+          content: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       Linux\nMemory Size:  16.00 GB\n",
           owner:  'root',
           group:  'root',
           mode:   '0644',
@@ -205,7 +205,7 @@ describe 'motd', type: :class do
         processor0: 'intel awesome',
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
-        memoryfree: '1 KB',
+        memorysize: '16.00 GB',
       }
     end
 
@@ -214,7 +214,7 @@ describe 'motd', type: :class do
         is_expected.to contain_Registry_value('HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\policies\system\legalnoticetext').with(
           ensure: 'present',
           type: 'string',
-          data: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       windows\nMemory Free:  1 KB\n",
+          data: "TestOS 5 x86_64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel awesome\nKernel:       windows\nMemory Size:  16.00 GB\n",
         )
       end
     end
@@ -252,7 +252,7 @@ describe 'motd', type: :class do
         processor0: 'intel',
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
-        memoryfree: '1 KB',
+        memorysize: '16.00 GB',
       }
     end
 
@@ -261,7 +261,7 @@ describe 'motd', type: :class do
         is_expected.to contain_File('/etc/motd').with(
           ensure: 'file',
           backup: 'false',
-          content: "TestOS 11 amd64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel\nKernel:       FreeBSD\nMemory Free:  1 KB\n",
+          content: "TestOS 11 amd64\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    intel\nKernel:       FreeBSD\nMemory Size:  16.00 GB\n",
         )
       end
     end
@@ -318,7 +318,7 @@ describe 'motd', type: :class do
         processor0: 'PowerPC_POWER8',
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
-        memoryfree: '1 KB',
+        memorysize: '16.00 GB',
       }
     end
 
@@ -327,7 +327,7 @@ describe 'motd', type: :class do
         is_expected.to contain_File('/etc/motd').with(
           ensure: 'file',
           backup: 'false',
-          content: "AIX 7100-04-02-1614 PowerPC_POWER8\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    \PowerPC_POWER8\nKernel:       AIX\nMemory Free:  1 KB\n",
+          content: "AIX 7100-04-02-1614 PowerPC_POWER8\n\nFQDN:         test.example.com (123.23.243.1)\nProcessor:    \PowerPC_POWER8\nKernel:       AIX\nMemory Size:  16.00 GB\n",
           owner:  'bin',
           group:  'bin',
           mode:   '0644',

--- a/templates/motd.epp
+++ b/templates/motd.epp
@@ -3,4 +3,4 @@
 FQDN:         <%= $facts[fqdn] %> (<%= $facts[ipaddress] %>)
 Processor:    <%= $facts[processor0] %>
 Kernel:       <%= $facts[kernel] %>
-Memory Free:  <%= $facts[memoryfree] %>
+Memory Size:  <%= $facts[memorysize] %>


### PR DESCRIPTION
As memoryfree is constantly changing, it does not make sense to include it in the template as this results in the file resource being changed during every agent run. I am changing this to memorysize since the other attributes in the template are related to the static hardware configuration of the machine.