### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To specify a string as the message of the day:
 
 ```puppet
 class { 'motd':
-  content => "Hello world!/n",
+  content => "Hello world!\n",
 }
 ```
 


### PR DESCRIPTION
No need to use double quotes when using a `/`, but I guess the `/n` here is a new line, and should have been written `\n`.