### PR TITLE
(FM-8275) Add vagrant provision list

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,10 @@ for:
     - bundle install --jobs 4 --retry 2
     - type Gemfile.lock
   test_script:
+     - bundle exec puppet -V
+     - ruby -v
+     - gem -v
+     - bundle -v
      - bundle exec rake spec_prep
      - bundle exec rake litmus:acceptance:localhost
 install:

--- a/provision.yaml
+++ b/provision.yaml
@@ -14,6 +14,9 @@ travis_el:
 waffle_el:
   provisioner: docker 
   images: ['waffleimage/centos6', 'waffleimage/centos7', 'waffleimage/oraclelinux6', 'waffleimage/oraclelinux7', 'waffleimage/scientificlinux6', 'waffleimage/scientificlinux7']
+vagrant:
+  provisioner: vagrant
+  images: ['centos/7', 'generic/ubuntu1804', 'gusztavvargadr/windows-server']
 release_checks:
   provisioner: vmpooler
   images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'oracle-5-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64', 'win-10-pro-x86_64']


### PR DESCRIPTION
Prior to this commit the only provisioners included in
the provision lists were docker and vmpooler, neither
of which are particularly accessible to folks developing
on Windows outside of Puppet.

This commit adds a list which leverages the vagrant
provisioner.