### PR TITLE
(PDK-1501) Allow Appveyor CI config to be templated

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,16 @@
 ---
 appveyor.yml:
-  unmanaged: true
+  use_litmus: true
+  matrix_extras:
+    -
+      RUBY_VERSION: 25-x64
+      ACCEPTANCE: "yes"
+      TARGET_HOST: localhost
+    -
+      RUBY_VERSION: 25-x64
+      ACCEPTANCE: "yes"
+      TARGET_HOST: localhost
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 .gitignore:
   required:
@@ -83,6 +93,7 @@ appveyor.yml:
     - rubocop-rspec
 
 Gemfile:
+  use_litmus: true
   optional:
     ':development':
       - gem: puppet-lint-i18n

--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,9 @@ group :development do
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-lint-i18n",                                        require: false
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 1.1.x.{build}
 branches:
   only:
     - master
+    - release
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10
@@ -42,8 +43,6 @@ environment:
       ACCEPTANCE: yes
       TARGET_HOST: localhost
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  #matrix:
-  #  fast_finish: true
 for:
 -
   matrix:
@@ -54,12 +53,14 @@ for:
     - bundle install --jobs 4 --retry 2
     - type Gemfile.lock
   test_script:
-     - bundle exec puppet -V
-     - ruby -v
-     - gem -v
-     - bundle -v
-     - bundle exec rake spec_prep
-     - bundle exec rake litmus:acceptance:localhost
+    - bundle exec puppet -V
+    - ruby -v
+    - gem -v
+    - bundle -v
+    - bundle exec rake spec_prep
+    - bundle exec rake litmus:acceptance:localhost
+matrix:
+  fast_finish: true
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - bundle install --jobs 4 --retry 2 --without system_tests

--- a/metadata.json
+++ b/metadata.json
@@ -97,6 +97,6 @@
   ],
   "description": "This module simply manages /etc/motd or the Windows Logon Message as a template, showing interpolation of system attributes",
   "template-url": "https://github.com/puppetlabs/pdk-templates/#master",
-  "template-ref": "1.14.1-0-g0b5b39b",
-  "pdk-version": "1.14.0"
+  "template-ref": "heads/master-0-g1a92949",
+  "pdk-version": "1.14.1"
 }


### PR DESCRIPTION
Previously the module unmanaged the Appveyor CI file when converted to Litmus.
This commit allows the Appveyor CI file to be managed.