### PR TITLE
FreeBSD compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,7 @@ class motd (
 
   $group = $facts['kernel'] ? {
     'AIX'   => 'bin',
+    'FreeBSD' => 'wheel',
     default => 'root',
   }
 


### PR DESCRIPTION
JIRA issue: MODULES-10336.

FreeBSD does not have a group called 'root' - it is called 'wheel'.