### PR TITLE
(WIP) test without update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - '[ -z "$RUBYGEMS_VERSION" ] || gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 script:

--- a/metadata.json
+++ b/metadata.json
@@ -97,7 +97,7 @@
     }
   ],
   "description": "This module simply manages /etc/motd or the Windows Logon Message as a template, showing interpolation of system attributes",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-g643529a",
+  "template-url": "https://github.com/DavidS/pdk-templates.git#update-only-on-request",
+  "template-ref": "remotes/origin/update-only-on-request-0-g0697835",
   "pdk-version": "1.14.1"
 }


### PR DESCRIPTION
PR for testing whether today's travis image works for us. it does.

The `bundle update --system` was originally added as a response to https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203 . See https://github.com/puppetlabs/puppetlabs-motd/blob/a56235c5fe6a7514ad3e13e9be840af76c997e5d/.travis.yml#L7-L9 