### PR TITLE
(maint) example for adding tags to tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
-
+gem 'puppet_litmus', git: 'https://github.com/sheenaajay/puppet_litmus.git', branch: 'takfortags', require: false, platforms: [:ruby, :mswin, :mingw, :x64_mingw] if ENV['PUPPET_GEM_VERSION'].nil? or ENV['PUPPET_GEM_VERSION'] !~ %r{ 5}
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
   file_url_regex = %r{\Afile:\/\/(?<path>.*)}

--- a/spec/acceptance/motd_spec.rb
+++ b/spec/acceptance/motd_spec.rb
@@ -69,7 +69,7 @@ def test_motd(pp, expected_contain, filename)
   expect(file(filename)).to contain expected_contain
 end
 
-describe 'Message of the day' do
+describe 'Message of the day', :integration do
   context 'when static message from content' do
     it do
       test_motd(pp_static_content, "Hello world!\n", motd_file)


### PR DESCRIPTION
Commands to run tagged testcases
To run on all nodes parallely
bundle exec rake 'litmus:acceptance:parallel['integration']'
To run on individual node
bundle exec rake 'litmus:acceptance:worth-pessimism.delivery.puppetlabs.net['integration']'