### PR TITLE
(maint) Don't abort matrix cells because of unrelated failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,6 +52,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
 
     steps:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -49,6 +49,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
 
     steps:


### PR DESCRIPTION
When running acceptance tests across platforms, usually
we should only be seeing platform-specific failures.
Hence aborting cells due to unrelated failures is
counter productive.

This change configures the jobs to let all matrix cells
run to completion.