### PR TITLE
(MAINT) Stale bot message bot_update

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,9 +11,22 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 60
-        days-before-close: 7
-        stale-issue-message: 'Hi, this issue has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your issue is still relevant and/or up-to-date.\n\nIf this issue is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed issues can still be reopened if you comment on them shortly after it has been closed.'
-        stale-issue-label: 'attention'
-        stale-pr-message: 'Hi, this PR has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your PR is still relevant and/or up-to-date.\n\nIf this PR is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed PRs can still be reopened if you comment on them shortly after it has been closed.'
-        stale-pr-label: 'needs-attention'
+        days-before-stale: 75
+        stale-issue-message: |
+          'Hello! 👋 
+          
+          This issue has been open for a while and has had no recent activity so it has been labeled as `attention-needed`.
+          
+          If you are waiting on a response from us we will try and address your comments in the next Community Day.
+          
+          Alternatively, if it is no longer relevant to you please close the issue with a comment.'
+        stale-issue-label: 'attention-needed'
+        stale-pr-message: |
+          'Hello! 👋 
+          
+          This pull request has been open for a while and has had no recent activity so it has been labeled as `attention-needed`.
+          
+          If you are waiting on a response from us we will try and address your comments in the next Community Day.
+          
+          Alternatively, if it is no longer relevant to you please close the pull-request with a comment.'
+        stale-pr-label: 'attention-needed'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,20 +13,20 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 75
         stale-issue-message: |
-          'Hello! 👋 
+          Hello! 👋 
           
           This issue has been open for a while and has had no recent activity so it has been labeled as `attention-needed`.
           
           If you are waiting on a response from us we will try and address your comments in the next Community Day.
           
-          Alternatively, if it is no longer relevant to you please close the issue with a comment.'
+          Alternatively, if it is no longer relevant to you please close the issue with a comment.
         stale-issue-label: 'attention-needed'
         stale-pr-message: |
-          'Hello! 👋 
+          Hello! 👋 
           
           This pull request has been open for a while and has had no recent activity so it has been labeled as `attention-needed`.
           
           If you are waiting on a response from us we will try and address your comments in the next Community Day.
           
-          Alternatively, if it is no longer relevant to you please close the pull-request with a comment.'
+          Alternatively, if it is no longer relevant to you please close the pull-request with a comment.
         stale-pr-label: 'attention-needed'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60
         days-before-close: 7
-        stale-issue-message: 'This issue has been marked as stale because it has been open for a while and has had no recent activity. If this issue is still important to you please drop a comment below and we will add this to our backlog to complete. Otherwise, it will be closed in 7 days.'
-        stale-issue-label: 'stale'
-        stale-pr-message: 'This PR has been marked as stale because it has been open for a while and has had no recent activity. If this PR is still important to you please drop a comment below and we will add this to our backlog to complete. Otherwise, it will be closed in 7 days.'
-        stale-pr-label: 'stale'
+        stale-issue-message: 'Hi, this issue has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your issue is still relevant and/or up-to-date.
+                              
+                              If this issue is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed issues can still be reopened if you comment on them shortly after it has been closed.'
+        stale-issue-label: 'attention'
+        stale-pr-message: 'Hi, this PR has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your PR is still relevant and/or up-to-date.
+                          
+                          If this PR is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed PRs can still be reopened if you comment on them shortly after it has been closed.'
+        stale-pr-label: 'attention'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,11 +13,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60
         days-before-close: 7
-        stale-issue-message: 'Hi, this issue has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your issue is still relevant and/or up-to-date.
-                              
-                              If this issue is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed issues can still be reopened if you comment on them shortly after it has been closed.'
+        stale-issue-message: 'Hi, this issue has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your issue is still relevant and/or up-to-date.\n\nIf this issue is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed issues can still be reopened if you comment on them shortly after it has been closed.'
         stale-issue-label: 'attention'
-        stale-pr-message: 'Hi, this PR has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your PR is still relevant and/or up-to-date.
-                          
-                          If this PR is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed PRs can still be reopened if you comment on them shortly after it has been closed.'
-        stale-pr-label: 'attention'
+        stale-pr-message: 'Hi, this PR has been open for a while and has had no recent activity so it has been labeled for attention. With significant change within our team over the past 6 months, we are no longer aware if your PR is still relevant and/or up-to-date.\n\nIf this PR is still important and relevant to you, please drop a comment below and we will add this back to our community workload for prioritisation. Otherwise, it will be considered inactive and will be closed after 7 days. Closed PRs can still be reopened if you comment on them shortly after it has been closed.'
+        stale-pr-label: 'needs-attention'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,22 +11,24 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 75
+        days-before-issue-stale: 90
+        days-before-pr-stale: 60
+        days-before-pr-close: 7
         stale-issue-message: |
-          Hello! 👋 
-          
-          This issue has been open for a while and has had no recent activity so it has been labeled as `attention-needed`.
-          
-          If you are waiting on a response from us we will try and address your comments in the next Community Day.
-          
+          Hello! 👋
+
+          This issue has been open for a while and has had no recent activity. We've labelled it with `attention-needed` so that we can get a clear view of which issues need our attention.
+
+          If you are waiting on a response from us we will try and address your comments on a future Community Day.
+
           Alternatively, if it is no longer relevant to you please close the issue with a comment.
         stale-issue-label: 'attention-needed'
         stale-pr-message: |
-          Hello! 👋 
-          
-          This pull request has been open for a while and has had no recent activity so it has been labeled as `attention-needed`.
-          
-          If you are waiting on a response from us we will try and address your comments in the next Community Day.
-          
-          Alternatively, if it is no longer relevant to you please close the pull-request with a comment.
+          Hello! 👋
+
+          This pull request has been open for a while and has had no recent activity. We've labelled it with `attention-needed` so that we can get a clear view of which PRs need our attention.
+
+          If you are waiting on a response from us we will try and address your comments on a future Community Day.
+
+          Alternatively, if it is no longer relevant to you please close the PR with a comment. Please note that if a pull request receives no update for 7 after it has been labelled, it will be closed. We are always happy to re-open pull request if they have been closed in error.
         stale-pr-label: 'attention-needed'


### PR DESCRIPTION
Prior to this commit, the stale bot would use a default message when
marking a community PR as 'stale'. This message wasn't very
descriptive and sometimes would come as too aggressive.

This commit aims to fix the stale bot by giving it a clearer
description of its role and job, as well as the situation of the PR
being marked.