### PR TITLE
(GH-422) Fix broken spec tests

### DIFF
--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -255,6 +255,11 @@ describe 'motd', type: :class do
         fqdn: 'test.example.com',
         ipaddress: '123.23.243.1',
         memorysize: '16.00 GB',
+        os: {
+          release: {
+            major: '11',
+          },
+        },
       }
     end
 


### PR DESCRIPTION
Prior to this PR spec tests were failing because a change was introduced that used hash map style syntax for retrieving facts.

The existing tests did not cater for this and would cause failures because the requested fact was not defined.

This PR fixes the issue by adding an OS has in to the defined facts for the FreeBSD spec.