### PR TITLE
pdksync - (CONT-189) Remove support for RedHat6 / OracleLinux6 / Scientific6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8",
         "9"

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
CONT-189/remove_os_support
pdk version: `2.5.0` 
