### PR TITLE
(CONT-422) - Pin changelog generator

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -11,6 +11,7 @@ Gemfile:
   optional:
     ":development":
     - gem: github_changelog_generator
+      version: '= 1.15.2'
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true


### PR DESCRIPTION
Versions above 1.15.2 seem to suffer from a dependency chain issue where the async gem implicitly sets the minimum supported ruby version to 3.0.

This change ensures that we pin to 1.15.2 in the .sync.yaml.