### PR TITLE
(CONT-860) Update registry dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 < 5.0.0"
+      "version_requirement": ">= 1.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Following the last major version update for puppetlabs-registry, several modules found themselves needing a dependency update. This commit aims to adjust the registry dependency within the module so that it is compatible with registry 5.0.0 and onwards.