### PR TITLE
(CAT-1805) Update tests to account for PDK integration

### DIFF
--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -47,7 +47,7 @@ describe 'motd', type: :class do
           # The following Regex checks for the matching content in this comment and allows for two different IP values to be matched after foo.example.com. This is a workaround to ensure that PDK
           # integration testing passes while the MOTD unit tests dont break. The string we are looking for is:
           # "RedHat 9.3 x86_64\n\nFQDN:         foo.example.com (172.16.254.254 OR 10.109.1.2)\nProcessor:    Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz\nKernel:       Linux\nMemory Size:  1.44 GiB\n",
-          content: %r{RedHat\s9\.3\sx86_64\n\nFQDN:\s*foo\.example\.com\s\((172\.16\.254\.254|10\.109\.1\.2)\)\nProcessor:\s*Intel\(R\)\sXeon\(R\)\s*.*\nKernel:\s*Linux\nMemory\sSize:\s*1.44\sGiB},
+          content: %r{RedHat\s9\.3\sx86_64\n\nFQDN:\s*foo\.example\.com\s\((172\.16\.254\.254|10\.109\.1\.2)\)\nProcessor:\s*Intel\(R\)\sXeon\(R\).*\nKernel:\s*Linux\nMemory\sSize:\s*\d+\.\d+\sGiB},
           owner: 'root', group: 'root', mode: '0644'
         )
       end
@@ -206,7 +206,7 @@ describe 'motd', type: :class do
           # The following Regex checks for the matching content in this comment and allows for two different IP values to be matched after foo.example.com. This is a workaround to ensure that PDK
           # integration testing passes while the MOTD unit tests dont break. The string we are looking for is:
           # "windows 10 x64\n\nFQDN:         foo.example.com (172.16.254.254)\nProcessor:    Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz\nKernel:       windows\nMemory Size:  14.34 GiB\n",
-          data: %r{windows\s10\sx64\n\nFQDN:\s*foo.example.com\s\((172\.16\.254\.254|10\.138\.1\.5)\)\nProcessor:\s*Intel\(R\)\sXeon\(R\)\sPlatinum\s8272CL\sCPU\s@\s2\.60GHz\nKernel:\s*windows\nMemory\sSize:\s*14\.34\sGiB}, # rubocop:disable Layout/LineLength
+          data: %r{windows\s10\sx64\n\nFQDN:\s*foo.example.com\s\((172\.16\.254\.254|10\.138\.1\.5)\)\nProcessor:\s*Intel\(R\)\sXeon\(R\).*\nKernel:\s*windows\nMemory\sSize:\s*\d+\.\d+\sGiB},
         )
       end
     end


### PR DESCRIPTION
This module is currently used in oder to test the PDK, with commands being run against it.
As part of this however the values returned by the tests I have updated here can vary between the PDK integration test suite on Jenkins and the MOTD test suite on Github Actions.
This change aims to resolve this by generalizing the expected values that can very between them.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)