### PR TITLE
(CAT-2463) Add bolt 5.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,10 +74,12 @@ group :system_tests do
 end
 
 gems = {}
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version


### PR DESCRIPTION
## Summary

This simple update to the module Gemfile ensures that modules will pull in **NOT ONLY** the puppetcore `puppet` and `facter` **BUT ALSO** the edge `bolt`.  For example, after a bundle install we see the expected bolt, puppet and facter versions:

```bash
➜  puppetlabs-motd git:(cat_2463_add_bolt_5) cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter|bolt|puppet_litmus)\s\(/'
  remote: https://rubygems-puppetcore.puppet.com/
    bolt (5.0.0)
    facter (4.15.0)
    puppet (8.15.0)
    puppet (8.15.0-universal-darwin)
  remote: https://rubygems.org/
    puppet_litmus (2.4.0)
➜  puppetlabs-motd git:(cat_2463_add_bolt_5) 
```
