### PR TITLE
(CAT-2624) Consolidate puppet_litmus gem calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,7 @@ group :development, :release_prep do
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem 'puppet_litmus', '~> 2.5',   require: false
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end


### PR DESCRIPTION
This PR aims to establish a single puppet_litmus gem version for all use cases. With the latest changes to litmus and actions, this means that fork PRs should default to public puppet testing instead of skipping tests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)