### PR TITLE
(CAT-2632) CI smoke test: verify safe-fork CI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ Puppet Labs modules on the Puppet Forge are open projects, and community contrib
 ## Contributors
 
 The list of contributors can be found at: [https://github.com/puppetlabs/puppetlabs-motd/graphs/contributors](https://github.com/puppetlabs/puppetlabs-motd/graphs/contributors).
+
+<!-- CI smoke test: verifying safe-fork CI workflow (CAT-2632). Safe to revert. -->

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Puppet Labs modules on the Puppet Forge are open projects, and community contrib
 The list of contributors can be found at: [https://github.com/puppetlabs/puppetlabs-motd/graphs/contributors](https://github.com/puppetlabs/puppetlabs-motd/graphs/contributors).
 
 <!-- CI smoke test: verifying safe-fork CI workflow (CAT-2632). Safe to revert. -->
+<!-- CI smoke test: second push to trigger synchronize event. -->


### PR DESCRIPTION
## Summary

- Trivial README tweak (an HTML comment) to trigger CI and verify the new safe-fork CI workflow from #554 runs as expected.
- This is a same-repo PR, so it exercises the `pull_request` path: `Spec` + `Acceptance` should run. It does **not** exercise the `pull_request_target` / `allowed-for-ci` label gate (that requires a PR from a fork).
- Safe to close/revert once CI has been observed.

## Test plan

- [x] `CI / Spec` runs and passes
- [x] `CI / Acceptance` runs (with `--nightly` flag) and passes
- [x] `Fork CI Label Guard` does **not** run (it's `pull_request_target`-only and this is same-repo)
- [x] No unexpected workflows triggered