### PR TITLE
(CAT-2632) Pin reusable workflows to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ concurrency:
 jobs:
   Spec:
     if: github.event_name != 'pull_request_target'
-    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@CAT-2632-enable_safe_fork_pr_ci"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
 
   Acceptance:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true && contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
-    uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@CAT-2632-enable_safe_fork_pr_ci"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
       flags: "--nightly"
     secrets: "inherit"

--- a/.github/workflows/fork_ci_label_guard.yml
+++ b/.github/workflows/fork_ci_label_guard.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   strip:
-    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@CAT-2632-enable_safe_fork_pr_ci"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@main"


### PR DESCRIPTION
## Summary

- Repoints the three reusable-workflow references in [.github/workflows/ci.yml](.github/workflows/ci.yml) and [.github/workflows/fork_ci_label_guard.yml](.github/workflows/fork_ci_label_guard.yml) from `@CAT-2632-enable_safe_fork_pr_ci` to `@main`.
- That feature branch in `puppetlabs/cat-github-actions` has been merged and no longer exists, so the current references are broken.

## Test plan

- [x] CI on this PR resolves the reusable workflows successfully (no \"workflow not found\" errors)
- [x] \`Spec\` and \`Acceptance\` jobs run and pass